### PR TITLE
Fix service start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ sudo systemctl enable dnsproxy
 
 Start the service
 ```
-sudo systemctl dnsproxy start
+sudo systemctl start dnsproxy
 ```
 
 Check that `dnsproxy` is running


### PR DESCRIPTION
The order was flipped the wrong way around.
`sudo systemctl dnsproxy start` should be `sudo systemctl start dnsproxy`